### PR TITLE
POST処理とDELETE処理のテスト実装

### DIFF
--- a/src/test/java/com/example/movie_list/MovieListServiceTest.java
+++ b/src/test/java/com/example/movie_list/MovieListServiceTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -39,7 +40,6 @@ public class MovieListServiceTest {
     @Test
     public void 存在する映画リストのIDを指定したとき正常に映画リストが返されること() throws Exception {
         doReturn(Optional.of(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カリキン", 476684675))).when(movieListMapper).findById(1);
-
         Movie actual = movieListService.findMovie(1);
         assertThat(actual).isEqualTo(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カリキン", 476684675));
     }
@@ -68,16 +68,19 @@ public class MovieListServiceTest {
 
     @Test
     public void 新しい映画リストを登録すること() {
-        Movie movie = new Movie("パイレーツ　オブ　カリビアン", LocalDate.of(2003, 07, 18), "ジョニー　デップ", 654264015);
-        assertThat(movieListService.insert("パイレーツ　オブ　カリビアン", LocalDate.of(2003, 07, 18), "ジョニー　デップ", 654264015)).isEqualTo(movie);
-        verify(movieListMapper).insert(movie);
+        Movie newMovie = new Movie("パイレーツ　オブ　カリビアン", LocalDate.of(2003, 7, 18), "ジョニー　デップ", 654264015);
+        doNothing().when(movieListMapper).insert(newMovie);
+        assertThat(movieListService.insert("パイレーツ　オブ　カリビアン", LocalDate.of(2003, 7, 18), "ジョニー　デップ", 654264015))
+                .isEqualTo(newMovie);
+        verify(movieListMapper).insert(newMovie);
     }
 
     @Test
     public void 存在する映画リストを削除すること() {
         int validId = 4;
         Movie existingMovie = new Movie(4, "バック　トゥ　ザ　フューチャー", LocalDate.of(1985, 12, 7), "マイケル　J　フォックス", 210609762);
-        when(movieListMapper.findById(4)).thenReturn(Optional.of(existingMovie));
+        when(movieListMapper.findById(validId)).thenReturn(Optional.of(existingMovie));
+        doNothing().when(movieListMapper).delete(validId);
         movieListService.delete(validId);
         verify(movieListMapper).delete(validId);
     }


### PR DESCRIPTION
# 概要
Serviceクラスにて、post処理、delete処理の単体テストを実装しました。

# 動作確認
- 新しい映画リストを登録すること
<img width="1359" alt="スクリーンショット 2024-08-07 3 20 06" src="https://github.com/user-attachments/assets/b740f4a8-c607-48fb-9fe1-3a003fcd55b5">

- 存在する映画リストを削除すること
<img width="1373" alt="スクリーンショット 2024-08-07 3 06 39" src="https://github.com/user-attachments/assets/185ee7da-be79-46a4-8532-1eeca8e62c7f">

- 指定したIDに映画リストがない場合は削除できないこと
<img width="1342" alt="スクリーンショット 2024-08-07 3 07 02" src="https://github.com/user-attachments/assets/7a3f4830-d052-43a8-a606-3f73cfd0f7d2">

