### PR TITLE
MapperのRead処理DBテストの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor 'org.projectlombok:lombok:1.18.26'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'com.github.database-rider:rider-spring:1.42.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.github.database-rider:rider-spring:1.42.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor 'org.projectlombok:lombok:1.18.26'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.github.database-rider:rider-spring:1.42.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -10,8 +10,8 @@ CREATE TABLE movies
   PRIMARY KEY(id)
 );
 
-INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('ホーム アローン', '1991-06-22', 'マコーレ カルキン', 476684675);
-INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('タイタニック','1997-12-20','レオナルド ディカプリオ', 658532551);
-INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('メリーに首ったけ','1999-01-30','キャメロン ディアス', 369884651);
-INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('バック  トゥ ザ フューチャー','1985-12-07','マイケル J フォックス', 210609762);
+INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('ホーム　アローン', '1991-06-22', 'マコーレ　カルキン', 476684675);
+INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('タイタニック','1997-12-20','レオナルド　ディカプリオ', 658532551);
+INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('メリーに首ったけ','1999-01-30','キャメロン　ディアス', 369884651);
+INSERT INTO movies (name, release_date, lead_actor, box_office)VALUES ('バック　トゥ　ザ　フューチャー','1985-12-07','マイケル　J　フォックス', 210609762);
 

--- a/src/main/java/com/example/movie_list/entity/Movie.java
+++ b/src/main/java/com/example/movie_list/entity/Movie.java
@@ -76,16 +76,28 @@ public class Movie {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Movie movie = (Movie) o;
-        return boxOffice == movie.boxOffice && Objects.equals(id, movie.id) &&
-                Objects.equals(name, movie.name) &&
-                Objects.equals(releaseDate, movie.releaseDate) &&
-                Objects.equals(leadActor, movie.leadActor) &&
-                Objects.equals(boxOffice, movie.boxOffice);
+        if (boxOffice != movie.boxOffice) return false;
+        if (!Objects.equals(id, movie.id)) return false;
+        if (!Objects.equals(name, movie.name)) return false;
+        if (!Objects.equals(releaseDate, movie.releaseDate)) return false;
+        return Objects.equals(leadActor, movie.leadActor);
+
+
+        //  return boxOffice == movie.boxOffice && Objects.equals(id, movie.id) &&
+        //         Objects.equals(name, movie.name) &&
+        //        Objects.equals(releaseDate, movie.releaseDate) &&
+        //      Objects.equals(leadActor, movie.leadActor) &&
+        //     Objects.equals(boxOffice, movie.boxOffice);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, releaseDate, leadActor, boxOffice);
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (releaseDate != null ? releaseDate.hashCode() : 0);
+        result = 31 * result + (leadActor != null ? leadActor.hashCode() : 0);
+        result = 31 * result + boxOffice;
+        return result;
     }
 
     @Override

--- a/src/main/java/com/example/movie_list/entity/Movie.java
+++ b/src/main/java/com/example/movie_list/entity/Movie.java
@@ -81,13 +81,6 @@ public class Movie {
         if (!Objects.equals(name, movie.name)) return false;
         if (!Objects.equals(releaseDate, movie.releaseDate)) return false;
         return Objects.equals(leadActor, movie.leadActor);
-
-
-        //  return boxOffice == movie.boxOffice && Objects.equals(id, movie.id) &&
-        //         Objects.equals(name, movie.name) &&
-        //        Objects.equals(releaseDate, movie.releaseDate) &&
-        //      Objects.equals(leadActor, movie.leadActor) &&
-        //     Objects.equals(boxOffice, movie.boxOffice);
     }
 
     @Override

--- a/src/main/java/com/example/movie_list/entity/Movie.java
+++ b/src/main/java/com/example/movie_list/entity/Movie.java
@@ -95,6 +95,15 @@ public class Movie {
 
     @Override
     public String toString() {
-        return "{\"id\":" + id + ",\"name\":\"" + name + "\"releaseDate\":" + releaseDate + "\"leadActor\":" + leadActor + "\"boxOffice\":" + boxOffice + "\"}";
+        return """
+                {
+                    "id": %d,
+                    "name": "%s",
+                    "releaseDate": "%s",
+                    "leadActor": "%s",
+                    "boxOffice": %d
+                }
+                """.formatted(id, name, releaseDate, leadActor, boxOffice);
     }
+
 }

--- a/src/test/java/com/example/movie_list/MovieListServiceTest.java
+++ b/src/test/java/com/example/movie_list/MovieListServiceTest.java
@@ -49,9 +49,9 @@ public class MovieListServiceTest {
     @Test
     public void すべての映画リストが取得できること() {
         List<Movie> movie = List.of(
-                new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カリキン", 476684675),
+                new Movie(1, "ホーム　アローン", LocalDate.of(1991, 6, 22), "マコーレ　カリキン", 476684675),
                 new Movie(2, "タイタニック", LocalDate.of(1997, 12, 20), "レオナルド　ディカプリオ", 658532551),
-                new Movie(3, "メリーに首ったけ", LocalDate.of(1999, 01, 30), "キャメロン　ディアス", 369884651),
+                new Movie(3, "メリーに首ったけ", LocalDate.of(1999, 1, 30), "キャメロン　ディアス", 369884651),
                 new Movie(4, "バック　トゥ　ザ　フューチャー", LocalDate.of(1985, 12, 07), "マイケル　J　フォックス", 210609762)
         );
         doReturn(movie).when(movieListMapper).findAll();

--- a/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
+++ b/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
@@ -1,0 +1,42 @@
+package com.example.movie_list.dao;
+
+import com.example.movie_list.entity.Movie;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class MovieListMapperTest {
+
+    @Autowired
+    private MovieListMapper movieListMapper;
+
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void すべての映画リストが取得できること() {
+        List<Movie> movies = movieListMapper.findAll();
+        assertThat(movies)
+                .hasSize(4)
+                .contains(
+                        new Movie(1, "ホーム　アローン", LocalDate.of(1991, 6, 22), "マコーレ カルキン", 476684675),
+                        new Movie(2, "タイタニック", LocalDate.of(1997, 12, 20), "レオナルド　ディカプリオ", 658532551),
+                        new Movie(3, "メリーに首ったけ", LocalDate.of(1999, 1, 30), "キャメロン　ディアス", 369884651),
+                        new Movie(4, "バック　トゥ　ザ　フューチャー", LocalDate.of(1985, 12, 7), "マイケル　J　フォックス", 210609762)
+                );
+    }
+
+}

--- a/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
+++ b/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
@@ -45,8 +45,9 @@ class MovieListMapperTest {
     @Transactional
     void 指定したIDの映画リストが取得できること() {
         Optional<Movie> actual = movieListMapper.findById(1);
-        Movie movie = new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カルキン", 476684675);
-        assertThat(actual.get()).isEqualTo(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カルキン", 476684675));
+        Movie expected = new Movie(1, "ホーム　アローン", LocalDate.of(1991, 6, 22), "マコーレ　カルキン", 476684675);
+        assertThat(actual).isPresent();
+        assertThat(actual.get()).isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
+++ b/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,11 +33,27 @@ class MovieListMapperTest {
         assertThat(movies)
                 .hasSize(4)
                 .contains(
-                        new Movie(1, "ホーム　アローン", LocalDate.of(1991, 6, 22), "マコーレ カルキン", 476684675),
+                        new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カルキン", 476684675),
                         new Movie(2, "タイタニック", LocalDate.of(1997, 12, 20), "レオナルド　ディカプリオ", 658532551),
-                        new Movie(3, "メリーに首ったけ", LocalDate.of(1999, 1, 30), "キャメロン　ディアス", 369884651),
-                        new Movie(4, "バック　トゥ　ザ　フューチャー", LocalDate.of(1985, 12, 7), "マイケル　J　フォックス", 210609762)
+                        new Movie(3, "メリーに首ったけ", LocalDate.of(1999, 01, 30), "キャメロン　ディアス", 369884651),
+                        new Movie(4, "バック　トゥ　ザ　フューチャー", LocalDate.of(1985, 12, 07), "マイケル　J　フォックス", 210609762)
                 );
     }
 
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void 指定したIDの映画リストが取得できること() {
+        Optional<Movie> actual = movieListMapper.findById(1);
+        Movie movie = new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カルキン", 476684675);
+        assertThat(actual.get()).isEqualTo(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カルキン", 476684675));
+    }
+
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void 存在しないIDを指定した場合は空のOptionalが返ること() {
+        Optional<Movie> movies = movieListMapper.findById(100);
+        assertThat(movies).isEmpty();
+    }
 }

--- a/src/test/resources/datasets/dbunit.yml
+++ b/src/test/resources/datasets/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+schema: movie_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/movie_list" # MySQLの場合
+  user: "user"
+  password: "password"

--- a/src/test/resources/datasets/movies.yml
+++ b/src/test/resources/datasets/movies.yml
@@ -1,0 +1,21 @@
+movies:
+  - id: 1
+    name: "ホーム アローン"
+    release_date: 1991-6-22
+    lead_actor: "マコーレ カルキン"
+    box_office: 476684675
+  - id: 2
+    name: "タイタニック"
+    release_date: 1997-12-20
+    lead_actor: "レオナルド ディカプリオ"
+    box_office: 658532551
+  - id: 3
+    name: "メリーに首ったけ"
+    release_date: 1999-01-30
+    lead_actor: "キャメロン ディアス"
+    box_office: 369884651
+  - id: 4
+    name: "バック  トゥ ザ フューチャー"
+    release_date: 1985-12-7
+    lead_actor: "マイケル J フォックス"
+    box_office: 210609762

--- a/src/test/resources/datasets/movies.yml
+++ b/src/test/resources/datasets/movies.yml
@@ -1,21 +1,21 @@
 movies:
   - id: 1
-    name: "ホーム アローン"
-    release_date: 1991-6-22
-    lead_actor: "マコーレ カルキン"
+    name: "ホーム　アローン"
+    release_date: 1991-06-22
+    lead_actor: "マコーレ　カルキン"
     box_office: 476684675
   - id: 2
     name: "タイタニック"
     release_date: 1997-12-20
-    lead_actor: "レオナルド ディカプリオ"
+    lead_actor: "レオナルド　ディカプリオ"
     box_office: 658532551
   - id: 3
     name: "メリーに首ったけ"
     release_date: 1999-01-30
-    lead_actor: "キャメロン ディアス"
+    lead_actor: "キャメロン　ディアス"
     box_office: 369884651
   - id: 4
-    name: "バック  トゥ ザ フューチャー"
-    release_date: 1985-12-7
-    lead_actor: "マイケル J フォックス"
+    name: "バック　トゥ　ザ　フューチャー"
+    release_date: 1985-12-07
+    lead_actor: "マイケル　J　フォックス"
     box_office: 210609762

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,7 +1,7 @@
 cacheConnection: false
 cacheTableNames: false
 properties:
-schema: movie_list
+  schema: movie_list
 caseInsensitiveStrategy: LOWERCASE
 connectionConfig:
   url: "jdbc:mysql://localhost:3307/movie_list" # MySQLの場合


### PR DESCRIPTION
# 概要
MapperclassのRead処理DBテストを実装しました。

# 動作確認
- すべての映画リストが取得できること
<img width="1358" alt="スクリーンショット 2024-08-11 16 50 27" src="https://github.com/user-attachments/assets/894d9844-8cc7-4a4b-baf6-99b140531308">

- 指定したIDの映画リストが取得できること
<img width="1382" alt="スクリーンショット 2024-08-11 16 51 12" src="https://github.com/user-attachments/assets/b11b736c-0cdd-41ea-96fa-857a5e3d24af">

- 存在しないIDを指定した場合は空のOptionalが返ること
<img width="1325" alt="スクリーンショット 2024-08-11 16 51 56" src="https://github.com/user-attachments/assets/faa2dec3-0112-4cd5-a8a6-691cac80f5e1">
