### PR TITLE
MapperのPOST DELETE PATCH処理のDBテストの実装

### DIFF
--- a/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
+++ b/src/test/java/com/example/movie_list/dao/MovieListMapperTest.java
@@ -2,12 +2,12 @@ package com.example.movie_list.dao;
 
 import com.example.movie_list.entity.Movie;
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DBRider
 @MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 class MovieListMapperTest {
 
     @Autowired
     private MovieListMapper movieListMapper;
 
+    //READ機能のDBテスト
     @Test
     @DataSet(value = "datasets/movies.yml")
     @Transactional
@@ -56,5 +56,37 @@ class MovieListMapperTest {
     void 存在しないIDを指定した場合は空のOptionalが返ること() {
         Optional<Movie> movies = movieListMapper.findById(100);
         assertThat(movies).isEmpty();
+    }
+
+    //POST機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @ExpectedDataSet(value = "datasets/expectedInsertmovies.yml", ignoreCols = "id")
+    @Transactional
+    void 新規の映画リストが正常に登録できること() {
+        Movie newMovie = new Movie("ターミネーター", LocalDate.of(1985, 8, 7), "アーノルド　シュワルツネガー", 503030035);
+        movieListMapper.insert(newMovie);
+        Optional<Movie> insertMovie = movieListMapper.findById(newMovie.getId());
+        assertThat(insertMovie).isNotEmpty();
+    }
+
+    //UPDATE機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @ExpectedDataSet(value = "datasets/expectedUpdatedmovies.yml")
+    @Transactional
+    void 存在する映画リストを更新すること() {
+        Movie movie = new Movie(1, "ホーム　アローン2", LocalDate.of(1995, 05, 02), "マコーレ　カルキン", 476684675);
+        movieListMapper.update(movie);
+    }
+
+    //DELETE機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @ExpectedDataSet(value = "datasets/expectedDeletemovies.yml")
+    void 指定したIDの映画リストが正常に削除できること() {
+        movieListMapper.delete(1);
+        List<Movie> deletemovie = movieListMapper.findAll();
+        assertThat(deletemovie).hasSize(3);
     }
 }

--- a/src/test/resources/datasets/expectedDeletemovies.yml
+++ b/src/test/resources/datasets/expectedDeletemovies.yml
@@ -1,9 +1,4 @@
 movies:
-  - id: 1
-    name: "ホーム　アローン"
-    release_date: '1991-06-22'
-    lead_actor: "マコーレ　カルキン"
-    box_office: 476684675
   - id: 2
     name: "タイタニック"
     release_date: '1997-12-20'
@@ -19,3 +14,4 @@ movies:
     release_date: '1985-12-07'
     lead_actor: "マイケル　J　フォックス"
     box_office: 210609762
+

--- a/src/test/resources/datasets/expectedInsertmovies.yml
+++ b/src/test/resources/datasets/expectedInsertmovies.yml
@@ -19,3 +19,8 @@ movies:
     release_date: '1985-12-07'
     lead_actor: "マイケル　J　フォックス"
     box_office: 210609762
+  - id: 5
+    name: "ターミネーター"
+    release_date: '1985-08-07'
+    lead_actor: "アーノルド　シュワルツネガー"
+    box_office: 503030035

--- a/src/test/resources/datasets/expectedUpdatedmovies.yml
+++ b/src/test/resources/datasets/expectedUpdatedmovies.yml
@@ -1,7 +1,7 @@
 movies:
   - id: 1
-    name: "ホーム　アローン"
-    release_date: '1991-06-22'
+    name: "ホーム　アローン2"
+    release_date: '1995-05-02'
     lead_actor: "マコーレ　カルキン"
     box_office: 476684675
   - id: 2


### PR DESCRIPTION
# 概要
MapperのPOST DELETE PATCH処理のDBテストを実装しました。

# 動作確認
- 新しい映画リストを登録すること
<img width="1333" alt="スクリーンショット 2024-08-17 9 08 24" src="https://github.com/user-attachments/assets/b11739d2-9a22-4ad9-b9ca-f796cb856767">

- 存在する映画リストを削除すること
<img width="1335" alt="スクリーンショット 2024-08-17 9 09 23" src="https://github.com/user-attachments/assets/057bf64b-b076-41e6-a4c0-9f6e4ca78a7d">

- 指定したIDに映画リストがない場合は削除できないこと
<img width="1329" alt="スクリーンショット 2024-08-17 9 10 27" src="https://github.com/user-attachments/assets/fef47af0-8204-4f56-85ce-d25ea7d498fa">

- 映画リストが正常に映画リストが更新されること
<img width="1342" alt="スクリーンショット 2024-08-17 9 11 01" src="https://github.com/user-attachments/assets/b8ae3ca5-1f8e-4f3c-a614-a93c5366f863">

- 存在しないIDの映画リストを更新しようとした時に例外が発生すること
<img width="1341" alt="スクリーンショット 2024-08-17 9 13 01" src="https://github.com/user-attachments/assets/846a8262-3190-4857-a345-ca59c5c1975d">

- 別のIDで既に登録されている映画リストを更新しようとした場合更新できないこと

<img width="1333" alt="スクリーンショット 2024-08-17 9 14 37" src="https://github.com/user-attachments/assets/ef4a9c7c-05f5-43f8-9f72-df355d53a47c">
