### PR TITLE
READ処理の結合テスト実装

### DIFF
--- a/src/main/java/com/example/movie_list/Controller/MovieListController.java
+++ b/src/main/java/com/example/movie_list/Controller/MovieListController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 public class MovieListController {
@@ -26,9 +27,17 @@ public class MovieListController {
         this.movieListService = movieListService;
     }
 
+    @GetMapping("/movies")
+    public ResponseEntity<List<Movie>> getAllMovies() {
+        List<Movie> movie = movieListService.findAll();
+        return ResponseEntity.ok(movie);
+    }
+
+
     @GetMapping("/movies/{id}")
-    public Movie findMovie(@Valid @PathVariable("id") int id) {
-        return movieListService.findMovie(id);
+    public ResponseEntity<Movie> findById(@PathVariable("id") Integer id) {
+        Movie movie = movieListService.findById(id);
+        return ResponseEntity.ok(movie);
     }
 
     @PostMapping("/movies")

--- a/src/main/java/com/example/movie_list/Service/MovieListService.java
+++ b/src/main/java/com/example/movie_list/Service/MovieListService.java
@@ -24,7 +24,7 @@ public class MovieListService {
         return movieListMapper.findAll();
     }
 
-    public Movie findMovie(int id) {
+    public Movie findById(int id) {
         return movieListMapper.findById(id)
                 .orElseThrow(() -> new MovieListNotFoundException("Movie with id " + id + " not found"));
     }
@@ -50,7 +50,7 @@ public class MovieListService {
     public Movie update(int id, String name, LocalDate releaseDate, String leadActor, int boxOffice) {
         Movie existingMovie = movieListMapper.findById(id)
                 .orElseThrow(() -> new MovieListNotFoundException("Movie with id " + id + " not found"));
-        
+
         Optional<Movie> duplicatedMovie = movieListMapper.findByName(name);
         duplicatedMovie.ifPresent(movie -> {
             if (!movie.getId().equals(id)) {

--- a/src/main/java/com/example/movie_list/dao/MovieListMapper.java
+++ b/src/main/java/com/example/movie_list/dao/MovieListMapper.java
@@ -17,7 +17,7 @@ public interface MovieListMapper {
     List<Movie> findAll();
 
     @Select("SELECT * FROM movies WHERE id =#{id}")
-    Optional<Movie> findById(int id);
+    Optional<Movie> findById(Integer id);
 
     @Select("SELECT * FROM movies WHERE name = #{name}")
     Optional<Movie> findByName(String name);

--- a/src/test/java/com/example/movie_list/MovieListServiceTest.java
+++ b/src/test/java/com/example/movie_list/MovieListServiceTest.java
@@ -42,7 +42,7 @@ public class MovieListServiceTest {
     @Test
     public void 存在する映画リストのIDを指定したとき正常に映画リストが返されること() throws Exception {
         doReturn(Optional.of(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カリキン", 476684675))).when(movieListMapper).findById(1);
-        Movie actual = movieListService.findMovie(1);
+        Movie actual = movieListService.findById(1);
         assertThat(actual).isEqualTo(new Movie(1, "ホーム　アローン", LocalDate.of(1991, 06, 22), "マコーレ　カリキン", 476684675));
     }
 
@@ -63,7 +63,7 @@ public class MovieListServiceTest {
     @Test
     public void 存在しないIDを指定した場合は例外が発生すること() {
         doReturn(Optional.empty()).when(movieListMapper).findById(0);
-        assertThatThrownBy(() -> movieListService.findMovie(0))
+        assertThatThrownBy(() -> movieListService.findById(0))
                 .isInstanceOf(MovieListNotFoundException.class);
         verify(movieListMapper).findById(0);
     }

--- a/src/test/java/com/example/movie_list/integrationtest/MovieListRestApiIntegrationTest.java
+++ b/src/test/java/com/example/movie_list/integrationtest/MovieListRestApiIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.example.movie_list.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class MovieListRestApiIntegrationTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void データベースに登録されている映画リストが全件取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/movies"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "name": "ホーム　アローン",
+                                "releaseDate": "1991-06-22",
+                                "leadActor": "マコーレ　カルキン",
+                                "boxOffice": 476684675
+                            },
+                            {
+                                "id": 2,
+                                "name": "タイタニック",
+                                "releaseDate": "1997-12-20",
+                                "leadActor": "レオナルド　ディカプリオ",
+                                "boxOffice": 658532551
+                            },
+                            {
+                                "id": 3,
+                                "name": "メリーに首ったけ",
+                                "releaseDate": "1999-01-30",
+                                "leadActor": "キャメロン　ディアス",
+                                "boxOffice": 369884651
+                            },
+                            {
+                                "id": 4,
+                                "name": "バック　トゥ　ザ　フューチャー",
+                                "releaseDate": "1985-12-07",
+                                "leadActor": "マイケル　J　フォックス",
+                                "boxOffice": 210609762
+                            }
+                        ]
+                        """));
+    }
+
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void 指定したIDの映画リストが存在する時にその映画リストを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/movies/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "id": 1,
+                            "name": "ホーム　アローン",
+                            "releaseDate": "1991-06-22",
+                            "leadActor": "マコーレ　カルキン",
+                            "boxOffice": 476684675
+                        },
+                                            """));
+    }
+
+    @Test
+    @DataSet(value = "datasets/movies.yml")
+    @Transactional
+    void 指定したIDの映画リストが存在しない時に例外処理が発生すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/movies/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+}


### PR DESCRIPTION
# 概要
Read処理の結合テストを実装しました。

# 動作確認
- データベースに登録されている映画リストが全件取得できること

<img width="1310" alt="スクリーンショット 2024-08-17 22 13 26" src="https://github.com/user-attachments/assets/cca4b3b2-d7d3-4b05-9b28-6b34f05df03f">

- 指定したIDの映画リストが存在する時にその映画リストを取得できること(ID=1を指定)

<img width="1297" alt="スクリーンショット 2024-08-17 22 15 28" src="https://github.com/user-attachments/assets/c50af7f3-7ae9-4abb-91f1-7bc1a4c954c0">

- 指定したIDの映画リストが存在しない時に例外処理が発生すること(ID=100を指定)

<img width="1296" alt="スクリーンショット 2024-08-17 22 17 30" src="https://github.com/user-attachments/assets/a3bca517-0818-4e52-b686-f1ed42c8d381">
